### PR TITLE
Fix: missing cookbook name inside metadata.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+chef-qt-webkit-devel Cookbook CHANGELOG
+====================================
+This file is used to list changes made in each version of the chef-qt-webkit-devel cookbook.
+
+1.0.1
+------
+### Bug
+- cookbook name missing in metadata.rb
+
+1.0
+------
+- Initial release

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,9 @@
+name             "chef-qt-webkit-devel"
 maintainer       "James Moriarty"
 maintainer_email "james@locomote.com"
 license          "MIT"
 description      ""
-version          "1.0"
+version          "1.0.1"
 
 %w{redhat centos}.each do |os|
   supports os


### PR DESCRIPTION
Using your cookbook with Berkshelf 3 causes an error due to missing cookbook name in metadata.rb.

I also set version number to canonical three figures and added CHANGELOG to track this modify.
